### PR TITLE
Allow passing a custom Writer to Transcriber

### DIFF
--- a/lib/Transcriber.php
+++ b/lib/Transcriber.php
@@ -52,6 +52,16 @@ class Transcriber
     private $speakerSegments = null;
 
     /**
+     * Create a new transcriber.
+     *
+     * @param Writer $writer
+     */
+    public function __construct(Writer $writer = null)
+    {
+        $this->writer = $writer ? $writer : new Writer;
+    }
+
+    /**
      * Accepts a string of encoded json and converts it into a buffered webVTT file
      *
      * @return string
@@ -59,7 +69,6 @@ class Transcriber
      */
     public function getOutputAsString(): string
     {
-        $this->writer = new Writer();
         $this->cueBuffer = new CueBuffer($this->secondPostponement);
         $this->speakerSegments = $this->awsTranscription->results->speaker_labels->segments ?? null;
 

--- a/lib/Writer.php
+++ b/lib/Writer.php
@@ -21,13 +21,13 @@ class Writer
      * String that will contain our output document
      * @var string
      */
-    private $outputString = '';
+    protected $outputString = '';
 
     /**
      * Time format that must be used in WebVTT documents
      * @var string
      */
-    private $outputTimeFormat = 'H:i:s\.v';
+    protected $outputTimeFormat = 'H:i:s\.v';
 
     /**
      * Writer constructor.
@@ -53,7 +53,7 @@ class Writer
     /**
      * Writes the header for the webvtt document
      */
-    private function writeHeader()
+    protected function writeHeader()
     {
         $this->writeLine('WEBVTT');
         $this->writeEmptyLine();
@@ -63,7 +63,7 @@ class Writer
      * Writes a new line to the file contents
      * @param string $contents
      */
-    private function writeLine(string $contents)
+    protected function writeLine(string $contents)
     {
         $this->outputString .= $contents . self::END_OF_LINE;
     }
@@ -71,7 +71,7 @@ class Writer
     /**
      * Writes an empty line to the file contents
      */
-    private function writeEmptyLine()
+    protected function writeEmptyLine()
     {
         $this->outputString .= self::END_OF_LINE;
     }
@@ -80,7 +80,7 @@ class Writer
      * @param DateTime $startTime
      * @param DateTime $endTime
      */
-    private function writeCueTime(DateTime $startTime, DateTime $endTime)
+    protected function writeCueTime(DateTime $startTime, DateTime $endTime)
     {
         $string = $startTime->format($this->outputTimeFormat) . ' --> ' . $endTime->format($this->outputTimeFormat);
         $this->writeLine($string);
@@ -89,7 +89,7 @@ class Writer
     /**
      * @param array $tracks
      */
-    private function writeCueTracks(array $tracks)
+    protected function writeCueTracks(array $tracks)
     {
         foreach ($tracks as $track) {
             $this->writeCueTrack($track);
@@ -99,7 +99,7 @@ class Writer
     /**
      * @param string $track
      */
-    private function writeCueTrack(string $track)
+    protected function writeCueTrack(string $track)
     {
         $this->writeLine('- ' . $track);
     }

--- a/tests/TranscriberTest.php
+++ b/tests/TranscriberTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use AwsTranscribeToWebVTT\Transcriber;
+use AwsTranscribeToWebVTT\Writer;
 use AwsTranscribeToWebVTT\Exception\NotJsonException;
 use PHPUnit\Framework\TestCase;
 
@@ -94,5 +95,19 @@ class TranscriberTest extends TestCase
             $result,
             'First word is broken immediately'
         );
+    }
+
+    public function testExtendingWriter()
+    {
+        $file = file_get_contents("./tests/stub/aws_transcription_stub.json");
+
+        $new = new Transcriber(new class extends Writer {
+            protected function writeCueTrack(string $track) {
+                $this->writeLine('- ' . strtoupper($track));
+            }
+        });
+        $result = $new->setAwsTranscription($file)->getOutputAsString();
+
+        $this->assertContains('THE BOTTOM LINE IS WE HAVE TO IMPROVE OUR', $result);
     }
 }


### PR DESCRIPTION
This PR adds a constructor to the Transcriber class which accepts a Writer class. A new Writer is created if no writer is passed to the constructor, allowing for backward compatibility. It also changes accessibility of the Writer class to protected, allowing the end-user to extend the Writer if they need to.

The reasoning behind this is that I want to do more customisation when writing cue tracks, so using these changes I can extend the Writer to make a new class which can then be passed for use in the Transcriber. I've also included a test that covers the new functionality.

Let me know what you think. 👍 